### PR TITLE
Remove Perkville Rewards Link

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -27,9 +27,6 @@
                     <li>
                         <a class="page-scroll" href="#contact">Contact</a>
                     </li>
-                    <li>
-                        <a href="http://www.perkville.com/biz/7482/">Perkville Rewards</a>
-                    </li>
                     <li class="header-widget">
                       <healcode-widget data-type="account-link" data-version="0.2" data-site-id="9719" data-inner-html="Login | Register"></healcode-widget>
                       <i data-behavior='login-video' data-modal-target='#login-video-modal' class='fa fa-question-circle login-video-icon'></i>

--- a/_includes/page_nav.html
+++ b/_includes/page_nav.html
@@ -18,9 +18,6 @@
                    <li class="hidden">
                        <a href="#page-top"></a>
                    </li>
-                   <li class="header-widget">
-                     <healcode-widget data-type="account-link" data-version="0.2" data-site-id="9719" data-inner-html="Login | Register"></healcode-widget>
-                   </li>
                    <li>
                        <a class="page-scroll" href="/#about">About</a>
                    </li>
@@ -30,8 +27,9 @@
                    <li>
                        <a class="page-scroll" href="/#contact">Contact</a>
                    </li>
-                   <li>
-                       <a href="http://www.perkville.com/biz/7482/">Perkville Rewards</a>
+                   <li class="header-widget">
+                     <healcode-widget data-type="account-link" data-version="0.2" data-site-id="9719" data-inner-html="Login | Register"></healcode-widget>
+                     <i data-behavior='login-video' data-modal-target='#login-video-modal' class='fa fa-question-circle login-video-icon'></i>
                    </li>
                </ul>
            </div>
@@ -39,3 +37,16 @@
        </div>
        <!-- /.container -->
    </nav>
+   <div class="modal fade" id="login-video-modal" tabindex="-1" role="dialog" aria-labelledby="login-video-modal-label" aria-hidden="true">
+     <div class="modal-dialog modal-lg">
+       <div class="modal-content">
+         <div class="modal-header">
+           <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+           <h4 class="modal-title" id="login-video-label">Registeration Demo</h4>
+         </div>
+         <div class="modal-body">
+           <iframe width="100%" height="500px" src="https://www.youtube.com/embed/JAGbo6tk5t0" frameborder="0" allowfullscreen></iframe>
+         </div>
+       </div>
+     </div>
+   </div>


### PR DESCRIPTION
@Ness0204: There is still Perkville info in the HelpCenter.  I'm leaving it for now, but let me know if you want that removed as well (you can also easily just remove [these lines](https://github.com/bemobilewellness/bemobilewellness.github.io/blob/master/_data/help_center/02-existing_corporate_clients.yml#L18-L25)).

Closes #25 

## Before
<img width="1163" alt="before" src="https://cloud.githubusercontent.com/assets/96776/18754291/005d1064-809d-11e6-88cf-0fa7c7402450.png">

## After
<img width="1163" alt="after" src="https://cloud.githubusercontent.com/assets/96776/18754290/005b04fe-809d-11e6-983e-1b3f211c2edf.png">
